### PR TITLE
add auto restart in service files

### DIFF
--- a/mainnet-v1/service.sh
+++ b/mainnet-v1/service.sh
@@ -14,8 +14,12 @@ EOF
 cat > bor.service <<EOF
 [Unit]
   Description=bor
+  StartLimitIntervalSec=500
+  StartLimitBurst=5
 
 [Service]
+  Restart=on-failure
+  RestartSec=5s
   WorkingDirectory=$NODE_DIR
   EnvironmentFile=/etc/matic/metadata
   ExecStartPre=/bin/chmod +x $NODE_DIR/bor/start.sh
@@ -30,8 +34,12 @@ EOF
 cat > heimdalld.service <<EOF
 [Unit]
   Description=heimdalld
+  StartLimitIntervalSec=500
+  StartLimitBurst=5
 
 [Service]
+  Restart=on-failure
+  RestartSec=5s
   WorkingDirectory=$NODE_DIR
   ExecStart=$BIN_DIR/heimdalld start
   Type=simple
@@ -44,8 +52,12 @@ EOF
 cat > heimdalld-rest-server.service <<EOF
 [Unit]
   Description=heimdalld-rest-server
+  StartLimitIntervalSec=500
+  StartLimitBurst=5
 
 [Service]
+  Restart=on-failure
+  RestartSec=5s
   WorkingDirectory=$NODE_DIR
   ExecStart=$BIN_DIR/heimdalld rest-server
   Type=simple


### PR DESCRIPTION
Source for reference and docs: https://ma.ttias.be/auto-restart-crashed-service-systemd/

If you add this config in the existing service file, please run `sudo systemctl daemon-reload` to reload the configuration.

