### PR TITLE
Removed deprecated static-nodes.json file

### DIFF
--- a/docker/mainnet.env
+++ b/docker/mainnet.env
@@ -7,7 +7,6 @@ HEIMDALL_ETH_RPC_URL=http://localhost:9545
 BOR_SETUP=https://raw.githubusercontent.com/maticnetwork/launch/master/mainnet-v1/sentry/sentry/bor/setup.sh
 BOR_START=https://raw.githubusercontent.com/maticnetwork/launch/master/mainnet-v1/sentry/sentry/bor/start.sh
 BOR_GENESIS=https://raw.githubusercontent.com/maticnetwork/launch/master/mainnet-v1/sentry/sentry/bor/genesis.json
-BOR_STATIC_FILE=https://raw.githubusercontent.com/maticnetwork/launch/master/mainnet-v1/sentry/sentry/bor/static-nodes.json
 BOR_BOOTNODES="enode://0cb82b395094ee4a2915e9714894627de9ed8498fb881cec6db7c65e8b9a5bd7f2f25cc84e71e89d0947e51c76e85d0847de848c7782b13c0255247a6758178c@44.232.55.71:30303,enode://88116f4295f5a31538ae409e4d44ad40d22e44ee9342869e7d68bdec55b0f83c1530355ce8b41fbec0928a7d75a5745d528450d30aec92066ab6ba1ee351d710@159.203.9.164:30303"
 HEIMDALL_FULL_NODE_SNAPSHOT_FILE="heimdall-fullnode-snapshot-2021-06-16.tar.gz"
 BOR_FULL_NODE_SNAPSHOT_FILE="bor-fullnode-snapshot-2021-06-16.tar.gz"

--- a/docker/matic-sentry-with-snapshotting.yml
+++ b/docker/matic-sentry-with-snapshotting.yml
@@ -51,7 +51,6 @@ services:
         cd /root \
         && wget -O setup.sh ${BOR_SETUP} \
         && wget -O genesis.json ${BOR_GENESIS} \
-        && wget -O static-nodes.json ${BOR_STATIC_FILE} \
         && sh setup.sh \
         && if [ ! -f \"start.sh\" ]
         then

--- a/docker/matic-sentry-without-snapshotting.yml
+++ b/docker/matic-sentry-without-snapshotting.yml
@@ -41,7 +41,6 @@ services:
         cd /root \
         && wget -O setup.sh ${BOR_SETUP} \
         && wget -O genesis.json ${BOR_GENESIS} \
-        && wget -O static-nodes.json ${BOR_STATIC_FILE} \
         && sh setup.sh \
         && wget -O start.sh ${BOR_START} \
         && if [ \"${BOR_MODE}\" == \"archive\" ]

--- a/docker/mumbai.env
+++ b/docker/mumbai.env
@@ -7,7 +7,6 @@ HEIMDALL_ETH_RPC_URL=http://localhost:9545
 BOR_SETUP=https://raw.githubusercontent.com/maticnetwork/launch/master/testnet-v4/sentry/sentry/bor/setup.sh
 BOR_START=https://raw.githubusercontent.com/maticnetwork/launch/master/testnet-v4/sentry/sentry/bor/start.sh
 BOR_GENESIS=https://raw.githubusercontent.com/maticnetwork/launch/master/testnet-v4/sentry/sentry/bor/genesis.json
-BOR_STATIC_FILE=https://raw.githubusercontent.com/maticnetwork/launch/master/testnet-v4/sentry/sentry/bor/static-nodes.json
 BOR_BOOTNODES="enode://095c4465fe509bd7107bbf421aea0d3ad4d4bfc3ff8f9fdc86f4f950892ae3bbc3e5c715343c4cf60c1c06e088e621d6f1b43ab9130ae56c2cacfd356a284ee4@18.213.200.99:30303"
 HEIMDALL_FULL_NODE_SNAPSHOT_FILE="heimdall-snapshot-2021-03-19.tar.gz"
 BOR_FULL_NODE_SNAPSHOT_FILE="bor-snapshot-2021-03-19.tar.gz"

--- a/mainnet-v1/sentry/sentry/bor/setup.sh
+++ b/mainnet-v1/sentry/sentry/bor/setup.sh
@@ -12,9 +12,6 @@ mkdir -p $BOR_DIR $BOR_DIR/keystore
 # init bor
 bor --datadir $DATA_DIR init ./genesis.json
 
-# copy peers file
-cp ./static-nodes.json $DATA_DIR/bor/static-nodes.json
-
 # if node key not present, create nodekey
 if [ ! -f $NODE_KEY ]; then
   bootnode -genkey $NODE_KEY

--- a/mainnet-v1/sentry/sentry/bor/static-nodes.json
+++ b/mainnet-v1/sentry/sentry/bor/static-nodes.json
@@ -1,4 +1,0 @@
-[
-  "<replace with enode://validator_machine_enodeID@validator_machine_ip:30303>",
-  "<replace with enode://other_public_machine_enode@sentry_machine_ip:30303>"
-]

--- a/mainnet-v1/sentry/validator/bor/setup.sh
+++ b/mainnet-v1/sentry/validator/bor/setup.sh
@@ -12,9 +12,6 @@ mkdir -p $BOR_DIR $BOR_DIR/keystore
 # init bor
 bor --datadir $DATA_DIR init ./genesis.json
 
-# copy peers file
-cp ./static-nodes.json $DATA_DIR/bor/static-nodes.json
-
 # if node key not present, create nodekey
 if [ ! -f $NODE_KEY ]; then
   bootnode -genkey $NODE_KEY

--- a/mainnet-v1/without-sentry/bor/setup.sh
+++ b/mainnet-v1/without-sentry/bor/setup.sh
@@ -12,9 +12,6 @@ mkdir -p $BOR_DIR $BOR_DIR/keystore
 # init bor
 bor --datadir $DATA_DIR init ./genesis.json
 
-# copy peers file
-cp ./static-nodes.json $DATA_DIR/bor/static-nodes.json
-
 # if node key not present, create nodekey
 if [ ! -f $NODE_KEY ]; then
   bootnode -genkey $NODE_KEY

--- a/testnet-v4/sentry/sentry/bor/setup.sh
+++ b/testnet-v4/sentry/sentry/bor/setup.sh
@@ -12,9 +12,6 @@ mkdir -p $BOR_DIR $BOR_DIR/keystore
 # init bor
 bor --datadir $DATA_DIR init ./genesis.json
 
-# copy peers file
-cp ./static-nodes.json $DATA_DIR/bor/static-nodes.json
-
 # if node key not present, create nodekey
 if [ ! -f $NODE_KEY ]; then
   bootnode -genkey $NODE_KEY

--- a/testnet-v4/sentry/sentry/bor/static-nodes.json
+++ b/testnet-v4/sentry/sentry/bor/static-nodes.json
@@ -1,4 +1,0 @@
-[
-  "<replace with enode://validator_machine_enodeID@validator_machine_ip:30303>",
-  "<replace with enode://other_public_machine_enode@sentry_machine_ip:30303>"
-]

--- a/testnet-v4/sentry/validator/bor/setup.sh
+++ b/testnet-v4/sentry/validator/bor/setup.sh
@@ -12,9 +12,6 @@ mkdir -p $BOR_DIR $BOR_DIR/keystore
 # init bor
 bor --datadir $DATA_DIR init ./genesis.json
 
-# copy peers file
-cp ./static-nodes.json $DATA_DIR/bor/static-nodes.json
-
 # if node key not present, create nodekey
 if [ ! -f $NODE_KEY ]; then
   bootnode -genkey $NODE_KEY

--- a/testnet-v4/without-sentry/bor/setup.sh
+++ b/testnet-v4/without-sentry/bor/setup.sh
@@ -12,9 +12,6 @@ mkdir -p $BOR_DIR $BOR_DIR/keystore
 # init bor
 bor --datadir $DATA_DIR init ./genesis.json
 
-# copy peers file
-cp ./static-nodes.json $DATA_DIR/bor/static-nodes.json
-
 # if node key not present, create nodekey
 if [ ! -f $NODE_KEY ]; then
   bootnode -genkey $NODE_KEY


### PR DESCRIPTION
The launch scripts still include the placeholder `static-nodes.json` file which apparently has been deprecated. The sample data in the file caused errors such as:
```
ERROR[03-20|08:49:53.246] Node URL <replace with enode://other_public_machine_enode@sentry_machine_ip:30303>: missing 'enr:' prefix for base64-encoded record
```
When the sample data was removed, the output then said:
```
Found deprecated node list file static-nodes.json, please use the TOML config file instead
```
I pulled out the deprecated file and unused environment variable so that the scripts no longer throw those errors. If users want to add static nodes, they can do so in their `config.toml` with:
```
[Node.P2P]
StaticNodes = []
```