### PR TITLE
Updated heimdall seeds to match the seeds from the polygon docs

### DIFF
--- a/docker/mainnet.env
+++ b/docker/mainnet.env
@@ -1,7 +1,7 @@
 HEIMDALL_TAG=mainnet-alchemy
 HEIMDALL_CHAIN_ID=heimdall-137
 HEIMDALL_GENESIS_URL=https://raw.githubusercontent.com/maticnetwork/launch/master/mainnet-v1/sentry/sentry/heimdall/config/genesis.json
-HEIMDALL_SEEDS="f4f605d60b8ffaaf15240564e58a81103510631c@159.203.9.164:26656,4fb1bc820088764a564d4f66bba1963d47d82329@44.232.55.71:26656"
+HEIMDALL_SEEDS="f4f605d60b8ffaaf15240564e58a81103510631c@159.203.9.164:26656,4fb1bc820088764a564d4f66bba1963d47d82329@44.232.55.71:26656,2eadba4be3ce47ac8db0a3538cb923b57b41c927@35.199.4.13:26656,3b23b20017a6f348d329c102ddc0088f0a10a444@35.221.13.28:26656,25f5f65a09c56e9f1d2d90618aa70cd358aa68da@35.230.116.151:26656"
 HEIMDALL_BOR_RPC_URL=http://bor0:8545
 HEIMDALL_ETH_RPC_URL=http://localhost:9545
 BOR_SETUP=https://raw.githubusercontent.com/maticnetwork/launch/master/mainnet-v1/sentry/sentry/bor/setup.sh


### PR DESCRIPTION
The Polygon docs for running a node found [here](https://docs.polygon.technology/docs/validate/validate/run-validator-binaries#configuring-the-heimdall-services) list four seeds while the current `mainnet.env` file only contains two of those. Those extra seeds help a lot when doing the initial sync, so I updated the seeds to match those in the docs.