### PR TITLE
Added check for heimdall+bor genesis

### DIFF
--- a/scripts/node_diagnostics.sh
+++ b/scripts/node_diagnostics.sh
@@ -82,3 +82,19 @@ if [ "$node" = "validator" ]; then
  fi
 fi
 
+# //check bor genesis
+
+chainId=$(bor attach ~/.bor/data/bor.ipc --exec admin.nodeInfo.protocols.eth.config.chainId ) # 137
+jaipurBlock=$(bor attach ~/.bor/data/bor.ipc --exec admin.nodeInfo.protocols.eth.config.bor.jaipurBlock) # 23850000
+
+if [ "$chainId" -ne "137" ] || [ "$jaipurBlock" -ne  "23850000" ]; then
+ echo -e "\e[31mBor is not init with correct Genesis."
+fi
+
+# //check heimdall genesis
+
+localGenesisTime=$(cat ~/.heimdalld/config/genesis.json | jq ".genesis_time") 
+remoteGenesisTime=$(curl -s https://raw.githubusercontent.com/maticnetwork/launch/master/mainnet-v1/sentry/sentry/heimdall/config/genesis.json | jq ".genesis_time")
+
+[[ "$localGenesisTime" == "$remoteGenesisTime" ]] || echo -e "\e[31mHeimdall is not init with correct Genesis."
+


### PR DESCRIPTION
## [Linear Task](https://linear.app/matic/issue/POS-433/add-genesis-check-in-node-diagnostics-script)

### Added the functionality for the node diagnosis script to check if bor and heimdall are running using the latest genesis file. 